### PR TITLE
[idea] #334 Multiple results with same file name leads to collisions.

### DIFF
--- a/plugins/idea/kodebeagleidea/checkstyle-config.xml
+++ b/plugins/idea/kodebeagleidea/checkstyle-config.xml
@@ -174,7 +174,9 @@
         <module name="HiddenField"/>
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
-        <module name="MagicNumber"/>
+        <module name="MagicNumber">
+         <property name="ignoreNumbers" value="-2, -1, 0, 1, 2, 3, 10"/>
+        </module>
         <module name="MissingSwitchDefault"/>
         <module name="RedundantThrows"/>
         <module name="SimplifyBooleanExpression"/>

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/action/EditSettingsAction.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/action/EditSettingsAction.java
@@ -17,7 +17,7 @@
 
 package com.imaginea.kodebeagle.action;
 
-import com.imaginea.kodebeagle.ui.SettingsConfigurable;
+import com.imaginea.kodebeagle.settings.ui.SettingsConfigurable;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/action/SearchKodeBeagleAction.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/action/SearchKodeBeagleAction.java
@@ -17,12 +17,12 @@
 
 package com.imaginea.kodebeagle.action;
 
+import com.imaginea.kodebeagle.ui.KBNotification;
 import com.imaginea.kodebeagle.ui.MainWindow;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindowManager;
-
 import java.io.IOException;
 
 public class SearchKodeBeagleAction extends AnAction {
@@ -37,6 +37,7 @@ public class SearchKodeBeagleAction extends AnAction {
                     try {
                         new RefreshAction().init();
                     } catch (IOException ioe) {
+                        KBNotification.getInstance().error(ioe);
                         ioe.printStackTrace();
                     }
                 }

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/model/CodeInfo.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/model/CodeInfo.java
@@ -22,7 +22,7 @@ import java.util.List;
 public class CodeInfo {
     private List<Integer> lineNumbers;
     private String contents;
-    private String fileName;
+    private String absoluteFileName;
 
     public final List<Integer> getLineNumbers() {
         return this.lineNumbers;
@@ -32,12 +32,12 @@ public class CodeInfo {
         return this.contents;
     }
 
-    public final String getFileName() {
-        return fileName;
+    public final String getAbsoluteFileName() {
+        return absoluteFileName;
     }
 
     public CodeInfo(final String pfileName, final List<Integer> plineNumbers) {
-        this.fileName = pfileName;
+        this.absoluteFileName = pfileName;
         this.lineNumbers = plineNumbers;
     }
 
@@ -46,7 +46,12 @@ public class CodeInfo {
     }
 
     public final String toString() {
-        return fileName.substring(fileName.lastIndexOf("/") + 1);
+        return absoluteFileName.substring(absoluteFileName.lastIndexOf("/") + 1);
     }
+
+    public final String getDisplayFileName() {
+        return absoluteFileName.substring(absoluteFileName.lastIndexOf("/") + 1);
+    }
+
 }
 

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/model/Settings.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/model/Settings.java
@@ -18,7 +18,7 @@
 package com.imaginea.kodebeagle.model;
 
 import com.imaginea.kodebeagle.action.RefreshAction;
-import com.imaginea.kodebeagle.ui.LimitsPanel;
+import com.imaginea.kodebeagle.settings.ui.LimitsPanel;
 import com.imaginea.kodebeagle.ui.MainWindow;
 import com.intellij.debugger.impl.DebuggerUtilsEx;
 import com.intellij.ide.util.PropertiesComponent;

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/object/WindowObjects.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/object/WindowObjects.java
@@ -17,7 +17,6 @@
 
 package com.imaginea.kodebeagle.object;
 
-import com.intellij.notification.Notification;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.components.JBScrollPane;
@@ -49,16 +48,6 @@ public final class WindowObjects {
     private String beagleId;
     private JPanel codePaneTinyEditorsJPanel;
     private JTabbedPane jTabbedPane;
-
-    public Notification getNotification() {
-        return notification;
-    }
-
-    public void setNotification(final Notification pNotification) {
-        this.notification = pNotification;
-    }
-
-    private Notification notification;
 
     private WindowObjects() {
 

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/ElasticSearchPanel.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/ElasticSearchPanel.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.imaginea.kodebeagle.ui;
+package com.imaginea.kodebeagle.settings.ui;
 
 import com.imaginea.kodebeagle.action.RefreshAction;
 import com.intellij.openapi.ui.ComboBox;

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/IdentityPanel.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/IdentityPanel.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.imaginea.kodebeagle.ui;
+package com.imaginea.kodebeagle.settings.ui;
 
 import java.awt.Font;
 import java.awt.GridBagConstraints;

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/ImportsPanel.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/ImportsPanel.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.imaginea.kodebeagle.ui;
+package com.imaginea.kodebeagle.settings.ui;
 
 import com.imaginea.kodebeagle.object.WindowObjects;
 import java.awt.GridBagConstraints;

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/LegalNotice.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/LegalNotice.java
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-package com.imaginea.kodebeagle.ui;
+package com.imaginea.kodebeagle.settings.ui;
 
-import com.imaginea.kodebeagle.util.ESUtils;
+import com.imaginea.kodebeagle.util.Utils;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.plugins.PluginManagerCore;
@@ -33,10 +33,7 @@ import com.intellij.util.ui.UIUtil;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
-import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
@@ -44,7 +41,6 @@ import javax.swing.JEditorPane;
 import javax.swing.JPanel;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -61,8 +57,8 @@ public class LegalNotice extends DialogWrapper {
     private static final String KODEBEAGLE_NOTICE_FILENAME = "KODEBEAGLE_NOTICE";
     //This is a temporary URL, we will host this page to our website soon.
     private static final String KODEBEAGLE_PRIVACY_POLICY = "<html><div style=\"text-align:left\">"
-           + "&nbsp;&nbsp;<a href=\"https://github.com/Imaginea/KodeBeagle/tree/master/"
-           + "docs/KodeBeaglePrivacyPolicy.html\">Privacy Policy</a></div><br></html>";
+            + "&nbsp;&nbsp;<a href=\"https://github.com/Imaginea/KodeBeagle/tree/master/"
+            + "docs/KodeBeaglePrivacyPolicy.html\">Privacy Policy</a></div><br></html>";
     private static final Dimension MESSAGE_EDITOR_PANE_PREFERRED_SIZE = new Dimension(500, 100);
     private static final BorderLayout LEGAL_NOTICE_LAYOUT = new BorderLayout(10, 0);
     private static boolean legalNoticeAccepted =
@@ -73,7 +69,7 @@ public class LegalNotice extends DialogWrapper {
         return legalNoticeAccepted;
     }
 
-    protected final void showLegalNotice() {
+    public final void showLegalNotice() {
         ApplicationManager.getApplication().invokeLater(new Runnable() {
             @Override
             public void run() {
@@ -82,7 +78,7 @@ public class LegalNotice extends DialogWrapper {
         });
     }
 
-    protected LegalNotice(@Nullable final Project pProject) {
+    public LegalNotice(@Nullable final Project pProject) {
         super(pProject);
         this.project = pProject;
         setTitle(LEGAL_NOTICE_TITLE);
@@ -150,16 +146,7 @@ public class LegalNotice extends DialogWrapper {
     private String getLegalNoticeMessage() {
         ClassLoader classLoader = this.getClass().getClassLoader();
         InputStream stream = classLoader.getResourceAsStream(KODEBEAGLE_NOTICE_FILENAME);
-        StringBuilder legalNoticeMessage = new StringBuilder();
-        try (BufferedReader reader =
-                     new BufferedReader(new InputStreamReader(stream, ESUtils.UTF_8))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                legalNoticeMessage.append(line);
-            }
-        } catch (IOException ioe) {
-            ioe.printStackTrace();
-        }
-        return String.format(legalNoticeMessage.toString());
+        return Utils.getInstance().readStreamFully(stream);
     }
+
 }

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/LimitsPanel.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/LimitsPanel.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.imaginea.kodebeagle.ui;
+package com.imaginea.kodebeagle.settings.ui;
 
 import com.imaginea.kodebeagle.action.RefreshAction;
 import com.intellij.util.ui.UIUtil;

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/NotificationPanel.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/NotificationPanel.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.imaginea.kodebeagle.ui;
+package com.imaginea.kodebeagle.settings.ui;
 
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/PatternFilterEditor.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/PatternFilterEditor.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.imaginea.kodebeagle.ui;
+package com.imaginea.kodebeagle.settings.ui;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/PatternFilterEditorAddDialog.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/PatternFilterEditorAddDialog.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.imaginea.kodebeagle.ui;
+package com.imaginea.kodebeagle.settings.ui;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/SettingsConfigurable.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/SettingsConfigurable.java
@@ -15,7 +15,7 @@
 * limitations under the License.
 */
 
-package com.imaginea.kodebeagle.ui;
+package com.imaginea.kodebeagle.settings.ui;
 
 import com.imaginea.kodebeagle.action.RefreshAction;
 import com.imaginea.kodebeagle.model.Settings;
@@ -40,7 +40,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class SettingsConfigurable implements Configurable {
 
-    protected static final String BEAGLE_ID = "Beagle ID:";
+    public static final String BEAGLE_ID = "Beagle ID:";
     public static final String KODE_BEAGLE_SETTINGS = "KodeBeagle Settings";
     private static final String NA = "Not Available";
     private SettingsPanel settingsPanel = new SettingsPanel();

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/SettingsPanel.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/settings/ui/SettingsPanel.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.imaginea.kodebeagle.ui;
+package com.imaginea.kodebeagle.settings.ui;
 
 import com.intellij.openapi.ui.ComboBox;
 import java.awt.GridBagConstraints;

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/ui/KBNotification.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/ui/KBNotification.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.imaginea.kodebeagle.ui;
+
+import com.imaginea.kodebeagle.action.RefreshAction;
+import com.imaginea.kodebeagle.object.WindowObjects;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationDisplayType;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.util.SimpleTimer;
+
+public final class KBNotification {
+    private static final KBNotification INSTANCE = new KBNotification();
+    private final WindowObjects windowObjects = WindowObjects.getInstance();
+    private final SimpleTimer simpleTimer = SimpleTimer.getInstance();
+
+    private KBNotification() {
+        // Restrict others from creating an INSTANCE.
+    }
+
+    private void schedule() {
+        final int delayMillis = 2500;
+        simpleTimer.setUp(new Runnable() {
+            @Override
+            public void run() {
+                KBNotification.this.expire();
+            }
+        }, delayMillis);
+    }
+
+    public static KBNotification getInstance() {
+        return INSTANCE;
+    }
+
+    private final NotificationGroup notificationsPassive = new NotificationGroup(
+            RefreshAction.KODEBEAGLE, NotificationDisplayType.NONE, true);
+
+    private final NotificationGroup notifications = new NotificationGroup(
+            RefreshAction.KODEBEAGLE, NotificationDisplayType.BALLOON, true);
+
+    private final NotificationGroup notificationsInvasive = new NotificationGroup(
+            RefreshAction.KODEBEAGLE, NotificationDisplayType.STICKY_BALLOON, true);
+
+    private Notification prevNotification;
+
+    private void expire() {
+        if (prevNotification != null) {
+            prevNotification.expire();
+        }
+    }
+
+    public Notification notifyInvasive(final String content,
+                                             final NotificationType type) {
+        expire();
+        prevNotification =
+                notificationsInvasive.createNotification(RefreshAction.KODEBEAGLE, content,
+                        type, null);
+        prevNotification.notify(windowObjects.getProject());
+        return prevNotification;
+    }
+
+    public Notification notifyPassive(final String content,
+                                            final NotificationType type) {
+        expire();
+        prevNotification =
+                notificationsPassive.createNotification(RefreshAction.KODEBEAGLE, content,
+                        type, null);
+        prevNotification.notify(windowObjects.getProject());
+        expire();
+        return prevNotification;
+    }
+
+    public Notification notifyBalloon(final String content,
+                                            final NotificationType type) {
+        expire();
+        prevNotification =
+                notifications.createNotification(RefreshAction.KODEBEAGLE, content,
+                        type, null);
+        prevNotification.notify(windowObjects.getProject());
+        schedule();
+        return prevNotification;
+    }
+
+    public void error(final Throwable t) {
+        expire();
+        prevNotification =
+                notifications.createNotification(RefreshAction.KODEBEAGLE,
+                        "<i>An exception occurred while processing your request:</i>" + t.toString()
+                                + "</br> Ideally it should be safe to ignore. "
+                                + "However if problem persists, please report it to us by "
+                                + "sending an email to kodebeagle@googlegroups.com",
+                        NotificationType.ERROR, null);
+        prevNotification.notify(windowObjects.getProject());
+    }
+
+}

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/ui/MainWindow.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/ui/MainWindow.java
@@ -178,11 +178,11 @@ public class MainWindow implements ToolWindowFactory {
                 + System.getProperty(OS_VERSION));
         windowObjects.setApplicationVersion(ApplicationInfo.getInstance().getVersionName()
                 + "/" + ApplicationInfo.getInstance().getBuild().toString());
-        IdeaPluginDescriptor codeBeagleVersion =
+        IdeaPluginDescriptor kodeBeagleVersion =
                 PluginManager.getPlugin(PluginId.getId(PLUGIN_ID));
 
-        if (codeBeagleVersion != null) {
-            windowObjects.setPluginVersion(IDEA_PLUGIN + "/" + codeBeagleVersion.getVersion());
+        if (kodeBeagleVersion != null) {
+            windowObjects.setPluginVersion(IDEA_PLUGIN + "/" + kodeBeagleVersion.getVersion());
         }
     }
 }

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/ui/MainWindow.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/ui/MainWindow.java
@@ -22,6 +22,8 @@ import com.imaginea.kodebeagle.action.EditSettingsAction;
 import com.imaginea.kodebeagle.action.ExpandProjectTreeAction;
 import com.imaginea.kodebeagle.action.RefreshAction;
 import com.imaginea.kodebeagle.object.WindowObjects;
+import com.imaginea.kodebeagle.settings.ui.LegalNotice;
+import com.imaginea.kodebeagle.settings.ui.SettingsConfigurable;
 import com.imaginea.kodebeagle.util.WindowEditorOps;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/ui/ProjectTree.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/ui/ProjectTree.java
@@ -140,9 +140,9 @@ public class ProjectTree {
         DefaultMutableTreeNode node = new DefaultMutableTreeNode(projectName);
         Collection<String> fileNameSet = new HashSet<String>();
         for (CodeInfo codeInfo : codeInfoCollection) {
-            if (!fileNameSet.contains(codeInfo.getFileName())) {
+            if (!fileNameSet.contains(codeInfo.getAbsoluteFileName())) {
                 node.add(new DefaultMutableTreeNode(codeInfo));
-                fileNameSet.add(codeInfo.getFileName());
+                fileNameSet.add(codeInfo.getAbsoluteFileName());
             }
         }
         return node;
@@ -190,7 +190,7 @@ public class ProjectTree {
             url = selectedNode.getUserObject().toString(); // getting project name
         } else if (root.getChildCount() > 0) {
             final CodeInfo codeInfo = (CodeInfo) selectedNode.getUserObject();
-            url = codeInfo.getFileName();
+            url = codeInfo.getAbsoluteFileName();
         }
         return url;
     }
@@ -199,16 +199,21 @@ public class ProjectTree {
         return new AbstractAction() {
             @Override
             public void actionPerformed(final ActionEvent actionEvent) {
-                VirtualFile virtualFile =
-                        editorDocOps.getVirtualFile(codeInfo.toString(),
-                                codeInfo.getContents());
-                FileEditorManager.getInstance(windowObjects.getProject()).
-                        openFile(virtualFile, true, true);
-                Document document =
-                        EditorFactory.getInstance().
-                                createDocument(codeInfo.getContents());
-                editorDocOps.addHighlighting(codeInfo.getLineNumbers(), document);
-                editorDocOps.gotoLine(codeInfo.getLineNumbers().get(0), document);
+                try {
+                    VirtualFile virtualFile =
+                            editorDocOps.getVirtualFile(codeInfo.getAbsoluteFileName(),
+                                    codeInfo.getDisplayFileName(), codeInfo.getContents());
+                    FileEditorManager.getInstance(windowObjects.getProject()).
+                            openFile(virtualFile, true, true);
+                    Document document =
+                            EditorFactory.getInstance().
+                                    createDocument(codeInfo.getContents());
+                    editorDocOps.addHighlighting(codeInfo.getLineNumbers(), document);
+                    editorDocOps.gotoLine(codeInfo.getLineNumbers().get(0), document);
+                } catch (Exception e) {
+                    e.printStackTrace();
+
+                }
             }
         };
     }
@@ -230,7 +235,7 @@ public class ProjectTree {
         public void run(@NotNull final ProgressIndicator indicator) {
             indicator.setText(FETCHING_FILE_CONTENT);
             indicator.setFraction(0.0);
-            String fileName = codeInfo.getFileName();
+            String fileName = codeInfo.getAbsoluteFileName();
             fileContents = esUtils.getContentsForFile(fileName);
 
             //Setting contents so that we can use that for Open in New Tab

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/ui/ProjectTree.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/ui/ProjectTree.java
@@ -211,8 +211,8 @@ public class ProjectTree {
                     editorDocOps.addHighlighting(codeInfo.getLineNumbers(), document);
                     editorDocOps.gotoLine(codeInfo.getLineNumbers().get(0), document);
                 } catch (Exception e) {
+                    KBNotification.getInstance().error(e);
                     e.printStackTrace();
-
                 }
             }
         };

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/util/ESUtils.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/util/ESUtils.java
@@ -72,7 +72,7 @@ public class ESUtils {
         return resultCount;
     }
 
-    public final void putContentsForFileInMap(final List<String> fileNames) {
+    public final void fetchContentsAndUpdateMap(final List<String> fileNames) {
         String esFileQueryJson = jsonUtils.getJsonForFileContent(fileNames);
         String esFileResultJson;
         esFileResultJson = getESResultJson(esFileQueryJson,
@@ -95,7 +95,7 @@ public class ESUtils {
                 windowObjects.getFileNameContentsMap();
 
         if (!fileNameContentsMap.containsKey(fileName)) {
-            putContentsForFileInMap(Arrays.asList(fileName));
+            fetchContentsAndUpdateMap(Arrays.asList(fileName));
         }
         String fileContent = fileNameContentsMap.get(fileName);
 

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/util/ESUtils.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/util/ESUtils.java
@@ -25,11 +25,10 @@ import com.google.gson.stream.JsonReader;
 import com.imaginea.kodebeagle.action.RefreshAction;
 import com.imaginea.kodebeagle.model.Settings;
 import com.imaginea.kodebeagle.object.WindowObjects;
+import com.imaginea.kodebeagle.ui.KBNotification;
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringReader;
-import java.net.MalformedURLException;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -176,20 +175,16 @@ public class ESUtils {
             }
             bufferedReader.close();
             httpClient.getConnectionManager().shutdown();
-        } catch (IllegalStateException e) {
-            e.printStackTrace();
-            return RefreshAction.EMPTY_ES_URL;
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-            return RefreshAction.EMPTY_ES_URL;
-        } catch (IOException e) {
-            e.printStackTrace();
-            return RefreshAction.EMPTY_ES_URL;
-        } catch (IllegalArgumentException e) {
-            e.printStackTrace();
-            return RefreshAction.EMPTY_ES_URL;
+        } catch (Exception e) {
+            return handleHttpException(e);
         }
         return stringBuilder.toString();
+    }
+
+    private String handleHttpException(final Exception e) {
+        KBNotification.getInstance().error(e);
+        e.printStackTrace();
+        return RefreshAction.EMPTY_ES_URL;
     }
 
     public final String getRepoStars(final String repoStarsJson) {

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/util/EditorDocOps.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/util/EditorDocOps.java
@@ -19,6 +19,7 @@ package com.imaginea.kodebeagle.util;
 
 import com.imaginea.kodebeagle.object.WindowObjects;
 import com.intellij.codeInsight.highlighting.HighlightUsagesHandler;
+import com.intellij.notification.NotificationGroup;
 import com.intellij.openapi.editor.CaretModel;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
@@ -34,8 +35,11 @@ import com.intellij.openapi.editor.markup.MarkupModel;
 import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.roots.PackageIndex;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.ToolWindowId;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -46,20 +50,27 @@ import com.intellij.psi.PsiJavaFile;
 import com.intellij.ui.Gray;
 import com.intellij.ui.JBColor;
 import java.awt.Color;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.nio.channels.Channel;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import org.apache.commons.codec.binary.Hex;
 import org.jetbrains.annotations.NotNull;
 
 public class EditorDocOps {
@@ -200,33 +211,73 @@ public class EditorDocOps {
         return excludedImports;
     }
 
-    public final VirtualFile getVirtualFile(final String fileName, final String contents) {
-        String tempDir = System.getProperty(JAVA_IO_TMP_DIR);
-        String filePath = tempDir + "/" + fileName;
-        File file = new File(filePath);
-        if (!file.exists()) {
-            try {
-                file.createNewFile();
-            } catch (IOException e1) {
-                e1.printStackTrace();
-            }
-        } else {
-            VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByPath(filePath);
-            windowEditorOps.setWriteStatus(virtualFile, true);
-        }
-        try {
-            BufferedWriter bufferedWriter =
-                    new BufferedWriter(
-                            new OutputStreamWriter(new FileOutputStream(file), ESUtils.UTF_8));
-            bufferedWriter.write(contents);
-            bufferedWriter.close();
-        } catch (IOException e1) {
-            e1.printStackTrace();
-        }
-        file.deleteOnExit();
+    public final VirtualFile getVirtualFile(final String fileName,
+                                            final String displayFileName,
+                                            final String contents)
+            throws IOException, NoSuchAlgorithmException {
+
+        final String tempDir = System.getProperty(JAVA_IO_TMP_DIR);
+        final String trimmedFileName =
+                FileUtil.sanitizeFileName(StringUtil.trimEnd(fileName, displayFileName));
+        final String digest = getDigestAsString(trimmedFileName);
+        final String fullFilePath = createFileWithContents(displayFileName, contents, tempDir, digest);
+        return getVirtualFile(fullFilePath, displayFileName, contents, tempDir);
+    }
+
+    private VirtualFile getVirtualFile(String filePath, String displayFileName, String contents,
+                                       String baseDir) throws IOException {
         VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByPath(filePath);
+        if (virtualFile == null) {
+            // This happens when intellij is confused about the existence of the file.
+            // Essentially it thinks the file was deleted, but we restored it.
+            // Unfortunately, it can not infer the fact that it was restored again.
+            String digest = UUID.randomUUID().toString().substring(0, 10);
+            final String fullFilePath = createFileWithContents(displayFileName, contents, baseDir, digest);
+            return getVirtualFile(fullFilePath, displayFileName, contents, baseDir);
+        }
         windowEditorOps.setWriteStatus(virtualFile, false);
         return virtualFile;
+    }
+
+
+    @NotNull
+    private String createFileWithContents(String displayFileName, String contents, String baseDir,
+                                          String digest) throws IOException {
+        final String fileParentPath =
+                String.format("%s%c%s", baseDir, File.separatorChar, digest);
+        final File parentDir = new File(fileParentPath);
+        FileUtil.createDirectory(parentDir);
+        parentDir.deleteOnExit();
+        final String fullFilePath =
+                String.format("%s%c%s",
+                        parentDir.getAbsolutePath(), File.separatorChar, displayFileName);
+        final File file = new File(fullFilePath);
+        if (!file.exists()) {
+            FileUtil.createIfDoesntExist(file);
+            forceWrite(contents, file);
+            file.deleteOnExit();
+        }
+        return fullFilePath;
+    }
+
+    private void forceWrite(String contents, File file) throws IOException {
+        FileOutputStream s = new FileOutputStream(file.getAbsolutePath(), false);
+        s.write(contents.getBytes());
+        FileChannel c = s.getChannel();
+        c.force(true);
+        s.getFD().sync();
+        c.close();
+        s.close();
+    }
+
+    @NotNull
+    private String getDigestAsString(final String trimmedFileName)
+            throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        MessageDigest crypt = MessageDigest.getInstance("SHA-1");
+        crypt.reset();
+        crypt.update(trimmedFileName.getBytes(StandardCharsets.UTF_8));
+        // We think 10 chars is safe enough to rely on.
+        return Hex.encodeHexString(crypt.digest()).substring(0, 10);
     }
 
     public final void addHighlighting(final List<Integer> linesForHighlighting,

--- a/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/util/Utils.java
+++ b/plugins/idea/kodebeagleidea/src/main/java/com/imaginea/kodebeagle/util/Utils.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.imaginea.kodebeagle.util;
+
+import com.imaginea.kodebeagle.ui.KBNotification;
+import com.intellij.openapi.util.io.FileUtil;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.apache.commons.codec.binary.Hex;
+import org.jetbrains.annotations.NotNull;
+
+public final class Utils {
+
+    private static final Utils INSTANCE = new Utils();
+
+    private Utils() {
+        // Restrict others from creating an instance.
+    }
+
+    public static Utils getInstance() {
+        return INSTANCE;
+    }
+
+    @NotNull
+    public String createFileWithContents(final String displayFileName, final String contents,
+                                         final String baseDir, final String digest)
+            throws IOException {
+
+        final String fileParentPath =
+                String.format("%s%c%s", baseDir, File.separatorChar, digest);
+        final File parentDir = new File(fileParentPath);
+        FileUtil.createDirectory(parentDir);
+        parentDir.deleteOnExit();
+        final String fullFilePath =
+                String.format("%s%c%s",
+                        parentDir.getAbsolutePath(), File.separatorChar, displayFileName);
+        final File file = new File(fullFilePath);
+        if (!file.exists()) {
+            FileUtil.createIfDoesntExist(file);
+            forceWrite(contents, file);
+            file.deleteOnExit();
+        }
+        return fullFilePath;
+    }
+
+    public void forceWrite(final String contents, final File file) throws IOException {
+        FileOutputStream s = new FileOutputStream(file.getAbsolutePath(), false);
+        s.write(contents.getBytes());
+        FileChannel c = s.getChannel();
+        c.force(true);
+        s.getFD().sync();
+        c.close();
+        s.close();
+    }
+
+    @NotNull
+    public String readStreamFully(final InputStream stream) {
+        StringBuilder legalNoticeMessage = new StringBuilder();
+        try (BufferedReader reader =
+                     new BufferedReader(new InputStreamReader(stream, ESUtils.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                legalNoticeMessage.append(line);
+            }
+        } catch (IOException ioe) {
+            KBNotification.getInstance().error(ioe);
+            ioe.printStackTrace();
+        }
+        return legalNoticeMessage.toString();
+    }
+
+    @NotNull
+    public String getDigestAsString(final String trimmedFileName)
+            throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        MessageDigest crypt = MessageDigest.getInstance("SHA-1");
+        crypt.reset();
+        crypt.update(trimmedFileName.getBytes(StandardCharsets.UTF_8));
+        // We think 10 chars is safe enough to rely on.
+        return Hex.encodeHexString(crypt.digest()).substring(0, 10);
+    }
+}

--- a/plugins/idea/kodebeagleidea/src/main/resources/META-INF/plugin.xml
+++ b/plugins/idea/kodebeagleidea/src/main/resources/META-INF/plugin.xml
@@ -71,7 +71,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow id="KodeBeagle" icon="AllIcons.Toolwindows.Documentation" anchor="right" factoryClass="com.imaginea.kodebeagle.ui.MainWindow"/>
-        <applicationConfigurable instance="com.imaginea.kodebeagle.ui.SettingsConfigurable"/>
+        <applicationConfigurable instance="com.imaginea.kodebeagle.settings.ui.SettingsConfigurable"/>
     </extensions>
 </idea-plugin>
 


### PR DESCRIPTION
1) Generate sha of project name to solve both long file name issue in windows.
2) Solve the problem of name collision by using full filename.

It also seems to solve the problem of NPE while using the plugin,
VFSDirectoryImpl will not adopt a file if it is accessed and later deleted.

So removing deleteOnExist seems to fix the problem.

This has a negative side that it may lead to using some extra space in a users temp
directory. But that should be hopefully okay.

closes #334
closes #329