### PR TITLE
[core] #522 Streamline the Repo analysis code and make it more modular.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
 jdk:
   - oraclejdk8
 install:
-  - IDEA_VERSION=15.0.4
+  - IDEA_VERSION=15.0.6
   - IDEA_TAR=ideaIC-${IDEA_VERSION}.tar.gz
   - SCALA_PLUGIN_VERSION=2.0.4
   - SCALA_PLUGIN_FULL=scala-intellij-bin-${SCALA_PLUGIN_VERSION}.zip

--- a/core/src/main/java/com/kodebeagle/javaparser/MethodInvocationResolver.java
+++ b/core/src/main/java/com/kodebeagle/javaparser/MethodInvocationResolver.java
@@ -18,13 +18,7 @@
 package com.kodebeagle.javaparser;
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jdt.core.dom.ClassInstanceCreation;
-import org.eclipse.jdt.core.dom.Expression;
-import org.eclipse.jdt.core.dom.MethodDeclaration;
-import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.jdt.core.dom.SimpleName;
-import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
-import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.*;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -37,361 +31,407 @@ import java.util.Stack;
 
 public class MethodInvocationResolver extends TypeResolver {
 
-	private Map<String, List<MethodInvokRef>> methodInvoks = new HashMap<String, List<MethodInvokRef>>();
-	private Stack<MethodDeclaration> methodStack = new Stack<MethodDeclaration>();
-	private List<MethodDecl> declaredMethods = new ArrayList<MethodDecl>();
-	private List<TypeDecl> typeDeclarations = new ArrayList<>();
-	private MethodInvokRef currentMethodInvokRef;
-	private static final String OBJECT_TYPE = "java.lang.Object";
-	protected Map<String,String> types = new HashMap();
-	protected Queue<String> typesInFile = new ArrayDeque<>();
-	protected String superType;
-	private List<Object> interfacesFullyQualifiedName = new ArrayList<Object>();
-	protected List<String> interfaces = new ArrayList<String>();
+    private static final String OBJECT_TYPE = "java.lang.Object";
 
-	public String getSuperType() {
-		return superType;
-	}
+    private Map<String, List<MethodInvokRef>> methodInvoks = new HashMap<String, List<MethodInvokRef>>();
+    private Stack<MethodDeclaration> methodStack = new Stack<MethodDeclaration>();
+    private List<MethodDecl> declaredMethods = new ArrayList<MethodDecl>();
+    private List<TypeDecl> typeDeclarations = new ArrayList<>();
+    protected Map<String, String> types = new HashMap();
+    protected Queue<String> typesInFile = new ArrayDeque<>();
+    protected String superType;
+    private List<Object> interfacesFullyQualifiedName = new ArrayList<Object>();
+    protected List<String> interfaces = new ArrayList<String>();
 
-	public List<TypeDecl> getTypeDeclarations() {
-		return typeDeclarations;
-	}
+    public String getSuperType() {
+        return superType;
+    }
 
-	public Map<String, List<MethodInvokRef>> getMethodInvoks() {
-		return methodInvoks;
-	}
+    public List<TypeDecl> getTypeDeclarations() {
+        return typeDeclarations;
+    }
 
-	public List<MethodDecl> getDeclaredMethods() {
-		return declaredMethods;
-	}
+    public Map<String, List<MethodInvokRef>> getMethodInvoks() {
+        return methodInvoks;
+    }
 
-	String type = "";
+    public List<MethodDecl> getDeclaredMethods() {
+        return declaredMethods;
+    }
 
-	private String removeSpecialSymbols(final String pType) {
-		String type = pType;
-		if (type != null && type.contains("<")) {
-			type = type.substring(0, type.indexOf("<"));
-		} else if (type != null && type.contains("[")) {
-			type = type.substring(0, type.indexOf("["));
-		}
-		return type;
-	}
+    String type = "";
 
-	@Override
-	public boolean visit(org.eclipse.jdt.core.dom.TypeDeclaration td) {
-		if (typesInFile.isEmpty()) {
-			type = "";
-		}
-		if (td.getSuperclassType() != null) {
-			superType = getFullyQualifiedNameFor(removeSpecialSymbols(td.getSuperclassType().toString()));
-		}
-		interfacesFullyQualifiedName.addAll(Arrays.<Object>asList(td.superInterfaceTypes().toArray()));
-		typesInFile.add(td.getName().getFullyQualifiedName());
-		String type = removeSpecialSymbols(td.getName().getFullyQualifiedName());
-		TypeDecl obj = new TypeDecl(type, td.getName().getStartPosition());
-		typeDeclarations.add(obj);
-		return true;
-	}
+    private String removeSpecialSymbols(final String pType) {
+        String type = pType;
+        if (type != null && type.contains("<")) {
+            type = type.substring(0, type.indexOf("<"));
+        } else if (type != null && type.contains("[")) {
+            type = type.substring(0, type.indexOf("["));
+        }
+        return type;
+    }
 
-	public Map<String, String> getTypes() {
-		return types;
-	}
+    @Override
+    public boolean visit(org.eclipse.jdt.core.dom.TypeDeclaration td) {
+        if (typesInFile.isEmpty()) {
+            type = "";
+        }
+        if (td.getSuperclassType() != null) {
+            superType = getFullyQualifiedNameFor(removeSpecialSymbols(td.getSuperclassType().toString()));
+        }
+        interfacesFullyQualifiedName.addAll(Arrays.<Object>asList(td.superInterfaceTypes().toArray()));
+        typesInFile.add(td.getName().getFullyQualifiedName());
+        String type = removeSpecialSymbols(td.getName().getFullyQualifiedName());
+        TypeDecl obj = new TypeDecl(type, td.getName().getStartPosition());
+        typeDeclarations.add(obj);
+        return true;
+    }
 
-	@Override
-	public void endVisit(org.eclipse.jdt.core.dom.TypeDeclaration td) {
-		if (!typesInFile.isEmpty()) {
-			String xyz = typesInFile.remove();
-			type = type + xyz + ".";
-			types.put(xyz, currentPackage + "." + type.substring(0, type.lastIndexOf(".")));
-		}
-	}
+    public Map<String, String> getTypes() {
+        return types;
+    }
 
-	@Override
-	public boolean visit(MethodDeclaration node) {
-		methodStack.push(node);
-		addMethodDecl(node);
-		return super.visit(node);
-	}
+    @Override
+    public void endVisit(org.eclipse.jdt.core.dom.TypeDeclaration td) {
+        if (!typesInFile.isEmpty()) {
+            String xyz = typesInFile.remove();
+            type = type + xyz + ".";
+            types.put(xyz, currentPackage + "." + type.substring(0, type.lastIndexOf(".")));
+        }
+    }
 
-	@Override
-	public void endVisit(MethodDeclaration node) {
-		if (!methodStack.isEmpty()) {
-			methodStack.pop();
-		}
-		super.endVisit(node);
-	}
+    @Override
+    public boolean visit(MethodDeclaration node) {
+        methodStack.push(node);
+        addMethodDecl(node);
+        return super.visit(node);
+    }
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public boolean visit(ClassInstanceCreation node) {
-		List args = node.arguments();
-		Map<String, Integer> scopeBindings = getNodeScopes().get(node);
-		List<String> argTypes = translateArgsToTypes(args, scopeBindings);
-		String type = getNameOfType(node.getType());
-		if (!methodStack.empty()) {
-			MethodDeclaration currentMethod = methodStack.peek();
-			String currMethodName = currentMethod.getName().toString();
-			List<MethodInvokRef> invoks = methodInvoks.get(currMethodName);
-			if (invoks == null) {
-				invoks = new ArrayList<MethodInvokRef>();
-				methodInvoks.put(currMethodName, invoks);
-			}
-			MethodInvokRef methodInvokRef = new MethodInvokRef(node.getType().toString(), type, "", args
-					.size(), node.getStartPosition(), argTypes, node.getLength());
-			invoks.add(methodInvokRef);
-			currentMethodInvokRef = methodInvokRef;
-		}
-		return super.visit(node);
-	}
+    @Override
+    public void endVisit(MethodDeclaration node) {
+        if (!methodStack.isEmpty()) {
+            methodStack.pop();
+        }
+        super.endVisit(node);
+    }
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public boolean visit(MethodInvocation node) {
-		SimpleName methodName = node.getName();
+    public boolean visit(Assignment assignment) {
+        return super.visit(assignment);
+    }
 
-		List args = node.arguments();
-		Expression expression = node.getExpression();
-		Map<String, Integer> scopeBindings = getNodeScopes().get(node);
-		String target = getTarget(expression);
-		String targetType = translateTargetToType(expression, scopeBindings);
-		List<String> argTypes = translateArgsToTypes(args, scopeBindings);
-		if (!methodStack.empty()) {
-			MethodDeclaration currentMethod = methodStack.peek();
-			String currMethodName = currentMethod.getName().toString();
-			List<MethodInvokRef> invoks = methodInvoks.get(currMethodName);
-			if (invoks == null) {
-				invoks = new ArrayList<MethodInvokRef>();
-				methodInvoks.put(currMethodName, invoks);
-			}
-			MethodInvokRef methodInvokRef = new MethodInvokRef(methodName.toString(), targetType, target, args
-					.size(), node.getName().getStartPosition(), argTypes, methodName.getLength());
-			invoks.add(methodInvokRef);
-			currentMethodInvokRef = methodInvokRef;
-		}
-		return true;
-	}
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean visit(ClassInstanceCreation node) {
+        List args = node.arguments();
+        Map<String, Integer> scopeBindings = getNodeScopes().get(node);
+        List<String> argTypes = translateArgsToTypes(args, scopeBindings);
+        String type = getNameOfType(node.getType());
+        if (!methodStack.empty()) {
+            MethodDeclaration currentMethod = methodStack.peek();
+            String currMethodName = currentMethod.getName().toString();
+            List<MethodInvokRef> invoks = methodInvoks.get(currMethodName);
+            if (invoks == null) {
+                invoks = new ArrayList<MethodInvokRef>();
+                methodInvoks.put(currMethodName, invoks);
+            }
+            MethodInvokRef methodInvokRef = new MethodInvokRef(node.getType().toString(), type, "", args
+                    .size(), node.getStartPosition(), argTypes, node.getLength(), true,
+                    getReturnType(node));
+            invoks.add(methodInvokRef);
+        }
+        return super.visit(node);
+    }
 
-	@SuppressWarnings("rawtypes")
-	private void addMethodDecl(MethodDeclaration node) {
-		SimpleName nameNode = node.getName();
-		String methodName = nameNode.toString();
-		List params = node.parameters();
-		int num = params.size();
-		List<String> paramTypes = new ArrayList<String>();
-		for (Object p : params) {
-			String typeName = OBJECT_TYPE;
-			if (p instanceof SingleVariableDeclaration) {
-				SingleVariableDeclaration svd = (SingleVariableDeclaration) p;
-				Type type = svd.getType();
-				typeName = getNameOfType(type);
-			} else {
-				System.err.println("Unxepected AST node type for param - " + p);
-			}
-			paramTypes.add(typeName);
-		}
-		declaredMethods.add(new MethodDecl(methodName, num, nameNode
-					.getStartPosition(), paramTypes));
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean visit(MethodInvocation node) {
+        SimpleName methodName = node.getName();
 
-	}
+        List args = node.arguments();
+        Expression expression = node.getExpression();
+        Map<String, Integer> scopeBindings = getNodeScopes().get(node);
+        String target = getTarget(expression);
+        String targetType = translateTargetToType(expression, scopeBindings);
+        List<String> argTypes = translateArgsToTypes(args, scopeBindings);
+        if (!methodStack.empty()) {
+            MethodDeclaration currentMethod = methodStack.peek();
+            String currMethodName = currentMethod.getName().toString();
+            List<MethodInvokRef> invoks = methodInvoks.get(currMethodName);
+            if (invoks == null) {
+                invoks = new ArrayList<MethodInvokRef>();
+                methodInvoks.put(currMethodName, invoks);
+            }
+            MethodInvokRef methodInvokRef = new MethodInvokRef(methodName.toString(), targetType, target, args
+                    .size(), node.getName().getStartPosition(), argTypes, methodName.getLength(), false,
+                    getReturnType(node));
+            invoks.add(methodInvokRef);
+        }
+        return true;
+    }
 
-	protected String translateTargetToType(Expression expression,
-			Map<String, Integer> scopeBindings) {
-		String targetType = "";
-		if (expression != null) {
-			String target = getTarget(expression);
-			final Integer variableId = scopeBindings.get(target);
-			if (variableId == null
-					|| !getVariableBinding().containsKey(variableId)) {
+    /**
+     * If the passed node is a method invocation or class creation then return the
+     * return type of the method based on what is the returned value assigned to.
+     * @param node
+     * @return return type
+     */
+    private String getReturnType(Expression node) {
+        ASTNode parent = node.getParent();
+        if (parent instanceof VariableDeclarationFragment) {
+            ASTNode grandParent = parent.getParent();
+            if (grandParent instanceof VariableDeclarationStatement) {
+                Type typ = ((VariableDeclarationStatement) grandParent).getType();
+                return getFullyQualifiedNameFor(typ.toString());
+            }
+        }
+        return null;
+    }
 
-				String staticTypeRef = getImportedNames().get(target);
-				if (staticTypeRef != null) {
-					// targetType = "<static>" + staticTypeRef;
-					targetType = staticTypeRef;
-				} else {
-					//System.out.println("Ignoring target " + target);
-				}
-			} else {
-				targetType = getVariableTypes().get(variableId);
-			}
-		}
-		return targetType;
-	}
+    @SuppressWarnings("rawtypes")
+    private void addMethodDecl(MethodDeclaration node) {
+        SimpleName nameNode = node.getName();
+        String methodName = nameNode.toString();
+        List params = node.parameters();
+        int num = params.size();
+        List<String> paramTypes = new ArrayList<String>();
+        for (Object p : params) {
+            String typeName = OBJECT_TYPE;
+            if (p instanceof SingleVariableDeclaration) {
+                SingleVariableDeclaration svd = (SingleVariableDeclaration) p;
+                Type type = svd.getType();
+                typeName = getNameOfType(type);
+            } else {
+                System.err.println("Unxepected AST node type for param - " + p);
+            }
+            paramTypes.add(typeName);
+        }
+        declaredMethods.add(new MethodDecl(methodName, num, nameNode
+                .getStartPosition(), paramTypes));
 
-	private String getTarget(Expression expression) {
-		String target = "";
-		if(expression != null){
-			target = expression.toString();
-			if (target.contains("this.")) {
-				target = StringUtils.substringAfter(target, "this.");
-			}
-		}
-		return target;
-	}
+    }
 
-	@SuppressWarnings("rawtypes")
-	protected List<String> translateArgsToTypes(List args,
-			Map<String, Integer> scopeBindings) {
-		List<String> argTypes = new ArrayList<String>();
-		for (Object o : args) {
-			String name = o.toString();
-			Integer varId = scopeBindings.get(name);
-			if (varId == null) {
-				String staticTypeRef = getImportedNames().get(name);
-				if (staticTypeRef != null) {
-					argTypes.add("<static>" + staticTypeRef);
-				} else {
-					argTypes.add(OBJECT_TYPE);
-				}
-			} else {
-				argTypes.add(getVariableTypes().get(varId));
-			}
-		}
-		return argTypes;
-	}
+    protected String translateTargetToType(Expression expression,
+                                           Map<String, Integer> scopeBindings) {
+        String targetType = "";
+        if (expression != null) {
+            String target = getTarget(expression);
+            final Integer variableId = scopeBindings.get(target);
+            if (variableId == null
+                    || !getVariableBinding().containsKey(variableId)) {
 
-	public List<String> getInterfaces() {
-		for (int i = 0; i < interfacesFullyQualifiedName.size(); i++)
-			interfaces.add(getFullyQualifiedNameFor(
-					removeSpecialSymbols(interfacesFullyQualifiedName.get(i).toString())));
-		return interfaces;
-	}
+                String staticTypeRef = getImportedNames().get(target);
+                if (staticTypeRef != null) {
+                    // targetType = "<static>" + staticTypeRef;
+                    targetType = staticTypeRef;
+                } else {
+                    //System.out.println("Ignoring target " + target);
+                }
+            } else {
+                targetType = getVariableTypes().get(variableId);
+            }
+        }
+        return targetType;
+    }
 
-	public static class TypeDecl {
-		private String className;
-		private Integer loc;
+    private String getTarget(Expression expression) {
+        String target = "";
+        if (expression != null) {
+            target = expression.toString();
+            if (target.contains("this.")) {
+                target = StringUtils.substringAfter(target, "this.");
+            }
+        }
+        return target;
+    }
 
-		public TypeDecl(String className, Integer loc) {
-			super();
-			this.className = className;
-			this.loc = loc;
-		}
+    @SuppressWarnings("rawtypes")
+    protected List<String> translateArgsToTypes(List args,
+                                                Map<String, Integer> scopeBindings) {
+        List<String> argTypes = new ArrayList<String>();
+        for (Object o : args) {
+            String name = o.toString();
+            Integer varId = scopeBindings.get(name);
+            if (varId == null) {
+                String staticTypeRef = getImportedNames().get(name);
+                if (staticTypeRef != null) {
+                    argTypes.add("<static>" + staticTypeRef);
+                } else {
+                    argTypes.add(OBJECT_TYPE);
+                }
+            } else {
+                argTypes.add(getVariableTypes().get(varId));
+            }
+        }
+        return argTypes;
+    }
 
-		public String getClassName() {
-			return className;
-		}
+    public List<String> getInterfaces() {
+        for (int i = 0; i < interfacesFullyQualifiedName.size(); i++)
+            interfaces.add(getFullyQualifiedNameFor(
+                    removeSpecialSymbols(interfacesFullyQualifiedName.get(i).toString())));
+        return interfaces;
+    }
 
-		public Integer getLoc() {
-			return loc;
-		}
-	}
+    public static class TypeDecl {
+        private String className;
+        private Integer loc;
 
-		public static class MethodDecl {
-		private String methodName;
-		private Integer argNum;
-		private Integer location;
-		private List<String> argTypes;
+        public TypeDecl(String className, Integer loc) {
+            super();
+            this.className = className;
+            this.loc = loc;
+        }
 
-		public MethodDecl(String methodName, Integer argNum, Integer location,
-				List<String> argTypes) {
-			super();
-			this.methodName = methodName;
-			this.argNum = argNum;
-			this.location = location;
-			this.argTypes = argTypes;
-		}
+        public String getClassName() {
+            return className;
+        }
 
-		public String getMethodName() {
-			return methodName;
-		}
+        public Integer getLoc() {
+            return loc;
+        }
+    }
 
-		public Integer getArgNum() {
-			return argNum;
-		}
+    public static class MethodDecl {
+        private String methodName;
+        private Integer argNum;
+        private Integer location;
+        private List<String> argTypes;
 
-		public Integer getLocation() {
-			return location;
-		}
+        public MethodDecl(String methodName, Integer argNum, Integer location,
+                          List<String> argTypes) {
+            super();
+            this.methodName = methodName;
+            this.argNum = argNum;
+            this.location = location;
+            this.argTypes = argTypes;
+        }
 
-		public List<String> getArgTypes() {
-			return argTypes;
-		}
+        public String getMethodName() {
+            return methodName;
+        }
 
-		@Override
-		public String toString() {
-			return "MethodDecl [methodName=" + methodName + ", argNum="
-					+ argNum + ", location=" + location + ", argTypes="
-					+ argTypes + "]";
-		}
+        public Integer getArgNum() {
+            return argNum;
+        }
 
-	}
+        public Integer getLocation() {
+            return location;
+        }
 
-	public static class MethodInvokRef {
-		private String methodName;
-		private String targetType;
-		private String target;
-		private Integer argNum;
-		private Integer location;
-		private Integer length;
-		private List<String> argTypes;
+        public List<String> getArgTypes() {
+            return argTypes;
+        }
 
-		private MethodInvokRef(String methodName, String targetType, String target,
-				Integer argNum, Integer location, List<String> argTypes, Integer length) {
-			super();
-			this.methodName = methodName;
-			this.targetType = targetType;
-			this.argNum = argNum;
-			this.location = location;
-			this.argTypes = argTypes;
-			this.target = target;
-			this.length =length;
+        @Override
+        public String toString() {
+            return "MethodDecl [methodName=" + methodName + ", argNum="
+                    + argNum + ", location=" + location + ", argTypes="
+                    + argTypes + "]";
+        }
 
-		}
+    }
 
-		public Integer getLength() {return length; }
-		public String getMethodName() {
-			return methodName;
-		}
+    public static class MethodInvokRef {
+        private String methodName;
+        private String targetType;
+        private String target;
+        private Integer argNum;
+        private Integer location;
+        private Integer length;
+        private String returnType;
+        private Boolean isConstructor;
+        private List<String> argTypes;
 
-		public void setMethodName(String methodName) {
-			this.methodName = methodName;
-		}
+        private MethodInvokRef(String methodName, String targetType, String target,
+                               Integer argNum, Integer location, List<String> argTypes, Integer length,
+                               Boolean isConstructor, String returnType) {
+            super();
+            this.methodName = methodName;
+            this.targetType = targetType;
+            this.argNum = argNum;
+            this.location = location;
+            this.argTypes = argTypes;
+            this.target = target;
+            this.length = length;
+            this.returnType = returnType;
+            this.isConstructor = isConstructor;
 
-		public String getTargetType() {
-			return targetType;
-		}
+        }
 
-		public void setTargetType(String targetType) {
-			this.targetType = targetType;
-		}
+        public Integer getLength() {
+            return length;
+        }
 
-		
-		public String getTarget() {
-			return target;
-		}
+        public String getMethodName() {
+            return methodName;
+        }
 
-		public void setTarget(String target) {
-			this.target = target;
-		}
+        public void setMethodName(String methodName) {
+            this.methodName = methodName;
+        }
 
-		public Integer getArgNum() {
-			return argNum;
-		}
+        public String getTargetType() {
+            return targetType;
+        }
 
-		public void setArgNum(Integer argNum) {
-			this.argNum = argNum;
-		}
+        public void setTargetType(String targetType) {
+            this.targetType = targetType;
+        }
 
-		public Integer getLocation() {
-			return location;
-		}
 
-		public void setLocation(Integer location) {
-			this.location = location;
-		}
+        public String getTarget() {
+            return target;
+        }
 
-		public List<String> getArgTypes() {
-			return argTypes;
-		}
+        public void setTarget(String target) {
+            this.target = target;
+        }
 
-		public void setArgTypes(List<String> argTypes) {
-			this.argTypes = argTypes;
-		}
+        public Integer getArgNum() {
+            return argNum;
+        }
 
-		@Override
-		public String toString() {
-			return "MethodInvokRef [methodName=" + methodName + ", targetType="
-					+ targetType + ", target=" + target + ", argNum=" + argNum
-					+ ", location=" + location + ", argTypes=" + argTypes + "]";
-		}
-	}
+        public void setArgNum(Integer argNum) {
+            this.argNum = argNum;
+        }
+
+        public Integer getLocation() {
+            return location;
+        }
+
+        public void setLocation(Integer location) {
+            this.location = location;
+        }
+
+        public List<String> getArgTypes() {
+            return argTypes;
+        }
+
+        public void setArgTypes(List<String> argTypes) {
+            this.argTypes = argTypes;
+        }
+
+        public Boolean getConstructor() {
+            return isConstructor;
+        }
+
+        public String getReturnType() {
+            return returnType;
+        }
+
+        @Override
+        public String toString() {
+            return "MethodInvokRef{" +
+                    "methodName='" + methodName + '\'' +
+                    ", targetType='" + targetType + '\'' +
+                    ", target='" + target + '\'' +
+                    ", argNum=" + argNum +
+                    ", location=" + location +
+                    ", length=" + length +
+                    ", returnType='" + returnType + '\'' +
+                    ", isConstructor=" + isConstructor +
+                    ", argTypes=" + argTypes +
+                    '}';
+        }
+    }
 }

--- a/core/src/main/java/com/kodebeagle/javaparser/SingleClassBindingResolver.java
+++ b/core/src/main/java/com/kodebeagle/javaparser/SingleClassBindingResolver.java
@@ -21,10 +21,10 @@ import com.google.common.collect.Maps;
 import com.kodebeagle.javaparser.MethodInvocationResolver.MethodDecl;
 import com.kodebeagle.javaparser.MethodInvocationResolver.MethodInvokRef;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import scala.Tuple2;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/core/src/main/java/com/kodebeagle/javaparser/TypeResolver.java
+++ b/core/src/main/java/com/kodebeagle/javaparser/TypeResolver.java
@@ -52,7 +52,7 @@ import java.util.Map.Entry;
  * <li>For each Type reference node, resolve the type to its fully qualified
  * name. E.g. in statement Type t = TypeFactory.getType(); 'Type' and
  * 'TypeFactory' nodes will be resolved to their fully qualified names at the
- * llocation.
+ * location.
  *
  * </ol>
  *
@@ -94,7 +94,7 @@ public class TypeResolver extends ASTVisitor {
 	private Map<ASTNode, String> nodeTypeBinding = Maps.newIdentityHashMap();
 
 	/**
-	 * For each importdeclaration node stores the type binding.
+	 * For each import declaration node stores the type binding.
 	 */
 	private Map<ASTNode, String> importsDeclarationNode = Maps.newIdentityHashMap();
 
@@ -102,8 +102,6 @@ public class TypeResolver extends ASTVisitor {
 	 * Contains the types of the variables at each scope.
 	 */
 	private Map<Integer, String> variableTypes = Maps.newTreeMap();
-
-	final Map<String, Integer> bindingsCopy = Maps.newTreeMap();
 
 	/**
 	 * Map of binding Id and variable definition node.
@@ -142,12 +140,12 @@ public class TypeResolver extends ASTVisitor {
 		return nodeScopes;
 	}
 
-	/**
-	 * Add the binding to the current scope.
-	 *
-	 * @param scopeBindings
-	 * @param name
-	 */
+    /**
+     * Add the binding to the current scope.
+     * @param node
+     * @param name
+     * @param type
+     */
 	private void addBinding(final ASTNode node, final SimpleName name,
 			final Type type) {
 		final int bindingId = nextVarId;
@@ -258,6 +256,7 @@ public class TypeResolver extends ASTVisitor {
 	public void preVisit(final ASTNode node) {
 		final ASTNode parent = node.getParent();
 		if (parent != null && nodeScopes.containsKey(parent)) {
+			Map<String, Integer> bindingsCopy = Maps.newTreeMap();
 			// inherit all variables in parent scope
 			for (final Entry<String, Integer> binding : nodeScopes.get(parent)
 					.entrySet()) {
@@ -303,7 +302,7 @@ public class TypeResolver extends ASTVisitor {
 
 	/**
 	 * Visits {@link SimpleName} AST nodes. Resolves the binding of the simple
-	 * name and looks for it in the {@link #variableScope} map. If the binding
+	 * name and looks for it in the {variableScope} map. If the binding
 	 * is found, this is a reference to a variable.
 	 *
 	 * @param node
@@ -346,7 +345,7 @@ public class TypeResolver extends ASTVisitor {
 	/**
 	 * Looks for local variable declarations. For every declaration of a
 	 * variable, the parent {@link Block} denoting the variable's scope is
-	 * stored in {@link #variableScope} map.
+	 * stored in {variableScope} map.
 	 *
 	 * @param node
 	 *            the node to visit

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -26,12 +26,18 @@ kodebeagle.github.crawlDir=/opt/jsProjects
 
 kodebeagle.indexing.linesOfContext=20
 
-kodebeagle.spark.master=local[15]
+kodebeagle.spark.master=spark://prinhydspln0153:7077
+#kodebeagle.spark.master=local[4]
 
 kodebeagle.spark.index.outputDir=tokens
 kodebeagle.spark.repo.outputDir=repo
 kodebeagle.spark.source.outputDir=source
 kodebeagle.spark.method.outputDir=method
+
+kodebeagle.repo.cloneDir=/tmp
+kodebeagle.repo.update.days=5
+# Or local path /repos/ etc
+kodebeagle.repo.remoteUrlPrefix=https://github.com/
 
 ######################################
 # Elasticsearch related configuration

--- a/core/src/main/scala/com/kodebeagle/configuration/KodeBeagleConfig.scala
+++ b/core/src/main/scala/com/kodebeagle/configuration/KodeBeagleConfig.scala
@@ -32,6 +32,10 @@ object KodeBeagleConfig extends ConfigReader{
   private[kodebeagle] val sparkSourceOutput = get("kodebeagle.spark.source.outputDir").get
   private[kodebeagle] val sparkMethodsOutput = get("kodebeagle.spark.method.outputDir").get
 
+  private[kodebeagle] val repoCloneDir: String = get("kodebeagle.repo.cloneDir").get
+  private[kodebeagle] val repoUpdateFreqDays: Int = get("kodebeagle.repo.update.days").get.toInt
+  private[kodebeagle] val remoteUrlPrefix: String = get("kodebeagle.repo.remoteUrlPrefix").get
+
   private[kodebeagle] val linesOfContext = get("kodebeagle.indexing.linesOfContext").get
   // This is required to use GithubAPIHelper
   private[kodebeagle] val githubTokens: Array[String] =

--- a/core/src/main/scala/com/kodebeagle/indexer/IndexEntities.scala
+++ b/core/src/main/scala/com/kodebeagle/indexer/IndexEntities.scala
@@ -17,6 +17,8 @@
 
 package com.kodebeagle.indexer
 
+import java.util
+
 import scala.collection.immutable
 
 trait Line {
@@ -90,4 +92,33 @@ object Repository {
   def invalid: Repository =
     Repository("n-a", -1, "n-a", fork = false, "Java", "n-a", 0, -1, -1, -1)
 }
+
+/* File Metadata related entities */
+case class RepoSource(repoId: Long, fileName: String, fileContent: String)
+
+case class TypeDeclaration(fileType: String, loc: String)
+
+case class ExternalRef(id: Int, fqt: String)
+
+case class VarTypeLocation(loc: String, id: Int)
+
+case class MethodTypeLocation(loc: String, id: Int, method: String, argTypes: List[String])
+
+case class MethodDefinition(loc: String, method: String, argTypes: List[String])
+
+case class InternalRef(childLine: String, parentLine: String)
+
+case class SuperTypes(superClass: String, interfaces: List[String])
+
+case class FileMetaData(repoId: Long, fileName: String, superTypes: SuperTypes,
+                        fileTypes: util.List[TypeDeclaration],
+                        externalRefList: List[ExternalRef],
+                        typeLocationList: List[VarTypeLocation],
+                        methodTypeLocation: List[MethodTypeLocation],
+                        methodDefinitionList: List[MethodDefinition],
+                        internalRefList: List[InternalRef])
+
+
+
+
 

--- a/core/src/main/scala/com/kodebeagle/model/BaseFileInfo.scala
+++ b/core/src/main/scala/com/kodebeagle/model/BaseFileInfo.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kodebeagle.model
+
+abstract class BaseFileInfo(val filePath: String) extends Serializable
+  with FileInfo with LazyLoadSupport {
+
+  val UNKNOWN_LANG: String = "Unknown"
+  private var _fileName: Option[String] = None
+  private var _language: Option[String] = None
+  private var _fileContent: Option[String] = None
+  private var _sloc: Option[Int] = None
+
+  // This extracts file name from path, without verifying if the file actually exists.
+  def fileName: String = {
+    getOrCompute(_fileName, () => {
+      _fileName = Option(extractFileName())
+      _fileName.get
+    })
+  }
+
+  // This extracts file language from path, without verifying if the file actually exists.
+  def language: String = {
+    getOrCompute(_language, () => {
+      _language = Option(extractLang())
+      _language.get
+    })
+  }
+
+  def fileContent: String = {
+    getOrCompute(_fileContent, () => {
+      _fileContent = Option(readFileContent())
+      _fileContent.get
+    })
+  }
+
+  def sloc: Int = {
+    getOrCompute(_sloc, () => {
+      _sloc = Option(readSloc())
+      _sloc.get
+    })
+  }
+
+  def extractFileName(): String
+
+  def extractLang(): String
+
+  def readFileContent(): String
+
+  def readSloc(): Int
+
+}
+

--- a/core/src/main/scala/com/kodebeagle/model/GithubRepo.scala
+++ b/core/src/main/scala/com/kodebeagle/model/GithubRepo.scala
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kodebeagle.model
+
+import java.io.File
+import java.nio.file.{Path, Paths}
+
+import com.kodebeagle.logging.Logger
+import com.kodebeagle.model.GithubRepo.GithubRepoInfo
+import org.apache.hadoop.conf.Configuration
+import org.eclipse.jgit.lib.{ObjectId, ObjectLoader, Ref, Repository}
+import org.eclipse.jgit.revwalk.{RevCommit, RevTree, RevWalk}
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+import org.eclipse.jgit.treewalk.TreeWalk
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
+/**
+  * This is an abstraction over a github repo that is to be analyzed.
+  *
+  * By default it will read the repo from the hdfs cluster and will throw
+  * RepoNotFoundException if it is not found.
+  *
+  * However, if update is set to `true` then it will first clone the repo
+  * from Github, replace the existing repo on Hdfs and read from that repo.
+  *
+  * @param repoPath -- repo location e.g. "apache/spark"
+  */
+class GithubRepo(val configuration: Configuration, val repoPath: String)
+  extends Repo with Logger with LazyLoadSupport {
+
+  private var _repository: Option[Repository] = None
+  private var _files: Option[List[GithubFileInfo]] = None
+  private var _stats: Option[RepoStatistics] = None
+  private var _languages: Option[Set[String]] = None
+
+  // TODO: How to get this? Two options:
+  // 1. Read directly from from Github using repo path.
+  //    (But this is likely to hit the github api rate limit)
+  // 2. Keep it stored upfront and pass it along in constructor.
+  val repoInfo: Option[GithubRepoInfo] = None
+
+  init()
+
+  def init(): Unit = {
+    val repoUpdateHelper = new GithubRepoUpdateHelper(configuration, repoPath)
+    if (repoUpdateHelper.shouldUpdate()) {
+      repoUpdateHelper.update()
+    }
+    val repoFiles = repoUpdateHelper.downloadLocalFromDfs()
+
+  }
+
+  override def files: List[GithubFileInfo] = {
+    getOrCompute(_files, () => {
+      _files = Option(readProject())
+      _files.get
+    })
+  }
+
+  override def statistics: RepoStatistics = {
+    getOrCompute(_stats, () => {
+      _stats = Option(calculateStats(files))
+      _stats.get
+    })
+  }
+
+  override def languages: Set[String] = {
+    getOrCompute(_languages, () => {
+      _languages = Option(extractLanguages(files))
+      _languages.get
+    })
+  }
+
+  def repository: Repository = {
+    val builder: FileRepositoryBuilder = new FileRepositoryBuilder
+    builder.setGitDir(new File(repoPath)).readEnvironment.findGitDir.build
+  }
+
+  def calculateStats(files: List[GithubFileInfo]): RepoStatistics = {
+    var slocSum: Int = 0
+    var sizeSum: Long = 0
+
+    for (fileInfo <- files) {
+      slocSum += fileInfo.sloc
+      sizeSum += fileInfo.fileContent.getBytes.length
+    }
+    val repoStatistics: RepoStatistics = new RepoStatistics {
+
+      override def sloc: Int = slocSum
+
+      override def fileCount: Int = files.size
+
+      override def size: Long = sizeSum
+    }
+    repoStatistics
+
+  }
+
+  def extractLanguages(files: List[GithubFileInfo]): Set[String] = {
+    val fileLanguages: mutable.Set[String] = mutable.Set[String]()
+    files.map(gitHubFileInfo => fileLanguages
+      .add(gitHubFileInfo.extractLang()))
+    fileLanguages.toSet
+  }
+
+
+  def readProject(): List[GithubFileInfo] = {
+    val gitRepo = repository
+
+    val gitHubFilesInfo: ArrayBuffer[GithubFileInfo] =
+      mutable.ArrayBuffer[GithubFileInfo]()
+
+
+    val head: Ref = gitRepo.getRef("HEAD")
+
+    // a RevWalk allows to walk over commits based on some filtering that is
+    // defined
+    val walk: RevWalk = new RevWalk(gitRepo)
+
+    val commit: RevCommit = walk.parseCommit(head.getObjectId)
+    val tree: RevTree = commit.getTree
+
+    // Now use a TreeWalk to iterate over all files in the Tree recursively
+    // We can set Filters to narrow down the results if needed
+    val treeWalk: TreeWalk = new TreeWalk(gitRepo)
+    treeWalk.addTree(tree)
+    treeWalk.setRecursive(true)
+    while (treeWalk.next) {
+      val githubFileInfo = new GithubFileInfo(treeWalk.getPathString,
+        treeWalk.getObjectId(0), gitRepo, repoInfo.get)
+      gitHubFilesInfo.append(githubFileInfo)
+    }
+
+    gitHubFilesInfo.toList
+  }
+
+}
+
+object GithubRepo {
+
+  case class GithubRepoInfo(login: String, id: Int, name: String, language: String,
+                            defaultBranch: String, stargazersCount: Int)
+
+}
+
+class GithubFileInfo(filePath: String, objectId: ObjectId, repository: Repository,
+                     githubRepoInfo: GithubRepoInfo) extends BaseFileInfo(filePath) {
+
+  override def extractFileName(): String = {
+    val p: Path = Paths.get(filePath)
+    p.getFileName.toString
+  }
+
+  override def readFileContent(): String = {
+    val loader: ObjectLoader = repository.open(objectId)
+    new String(loader.getBytes(), "UTF-8")
+  }
+
+  override def extractLang(): String = {
+    val fileType: Array[String] = filePath.split("\\.")
+    if (fileType.length > 1) {
+      fileType(1)
+    }
+    UNKNOWN_LANG
+  }
+
+  override def readSloc(): Int = {
+    Source.fromString(fileContent).getLines().size
+  }
+
+  override def repoFileLocation: String = {
+    s"${githubRepoInfo.login}/${githubRepoInfo.name}/blob/${githubRepoInfo.defaultBranch}/"
+  }
+
+  override def repoId: Int = {
+    githubRepoInfo.id
+  }
+}
+

--- a/core/src/main/scala/com/kodebeagle/model/GithubRepoUpdateHelper.scala
+++ b/core/src/main/scala/com/kodebeagle/model/GithubRepoUpdateHelper.scala
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kodebeagle.model
+
+import java.io.File
+
+import com.kodebeagle.configuration.KodeBeagleConfig
+import com.kodebeagle.logging.Logger
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{Path, FileSystem}
+
+import scala.collection.mutable.ListBuffer
+
+class GithubRepoUpdateHelper(val configuration: Configuration,
+                             val repoPath: String) extends Logger {
+
+  import sys.process._
+  import GithubRepoUpdateHelper._
+
+  // TODO: Get these from configuration?
+  val remoteUrlPrefix = "https://github.com/"
+  val masterBranchName = "master"
+  val gitDBName = "git.tar.gz"
+  val fsRepoDirPath = "/kodebeagle/repos/"
+
+  def fs: FileSystem = FileSystem.get(configuration)
+
+  def localCloneDir: String = KodeBeagleConfig.repoCloneDir
+
+  def fsRepoPath: Path = new Path(join("", fsRepoDirPath, repoPath))
+
+  def localRepoPath: String = join(File.separator, localCloneDir, repoPath)
+
+  def localBranchPath: String = join(File.separator, localRepoPath, masterBranchName)
+
+  def localGitPath: String = join(File.separator, localRepoPath, gitDBName)
+
+  /**
+    * Checks if the repository exists on fs, if not then return true.
+    * If yes, then checks what its modification time was, if the time since
+    * exceeds a configured maximum then repository is marked for update (i.e.
+    * false is returned).
+    *
+    * @return - whether to update (reclone) this repository from Guthub
+    */
+  def shouldUpdate(): Boolean = {
+    val exists = fs.exists(fsRepoPath)
+    var shouldUpdate = false
+    if (exists) {
+      val filestatus = fs.getFileStatus(new Path(join(File.separator,
+        fsRepoPath.toString, gitDBName)))
+      val elapsedTime = System.currentTimeMillis - filestatus.getModificationTime
+      if (elapsedTime / (1000 * 60 * 60 * 24) > KodeBeagleConfig.repoUpdateFreqDays) {
+        shouldUpdate = true
+      }
+    } else {
+      shouldUpdate = true
+    }
+    shouldUpdate
+  }
+
+  /**
+    * Does the actual updating of a github repo in following steps:
+    * 1. Clone the repository on to the local file system.
+    * 2. tar it
+    * 3. Upload the local tar(s) to fs
+    *
+    * @return - true if the repo was updated successfully
+    */
+  def update(): Boolean = {
+    val cloneUrl = remoteUrlPrefix + repoPath
+    val repoName = repoPath.split("/")(1)
+
+    val cleanClone = buildCloneCommand(repoName, cloneUrl)
+
+    val tarMasterCmd = bashCmdsFromDir(localRepoPath,
+      Seq(
+        s"""cd ${localRepoPath}""",
+        s"""tar -zcf master.tar.gz ${repoName}/ --exclude "${repoName}/.git""""))
+
+    val tarGitCmd = bashCmdsFromDir(localRepoPath,
+      Seq(
+        s"""cd ${localRepoPath}""",
+        s"""tar -zcf git.tar.gz ${repoName}/.git/"""))
+
+    log.debug("Clean clone command is : " + cleanClone)
+    log.debug("Tar master command is : " + tarMasterCmd)
+    log.debug("Tar git command is : " + tarGitCmd)
+
+    cleanClone.!!
+    tarMasterCmd.!!
+    tarGitCmd.!!
+
+    val pathsToCopy = Array(new Path(s"""${localRepoPath}/master.tar.gz"""),
+      new Path(s"""${localRepoPath}/git.tar.gz"""))
+
+    fs.mkdirs(fsRepoPath)
+    fs.copyFromLocalFile(true, true, pathsToCopy, fsRepoPath)
+
+    true
+  }
+
+  // TODO: Rename to load()?
+
+  /**
+    * @return -- list of files downloaded from hdfs for this repo
+    */
+
+  def downloadLocalFromDfs(): List[String] = {
+    import sys.process._
+
+    val files = fs.listStatus(fsRepoPath);
+    val fileBuff = ListBuffer[String]()
+    val localRepoCrtOp = Seq("/bin/bash", "-c", s"""mkdir -p ${localRepoPath})""").!!
+    log.info(localRepoCrtOp)
+    for (f <- files) {
+      val fileName = f.getPath().getName
+      f.getModificationTime
+      val localFilePath = join(File.separator, localRepoPath, fileName)
+      fs.copyToLocalFile(false, f.getPath, new Path(localFilePath))
+      if (f.getPath().getName.endsWith("gz")) {
+        val output = s"""tar -xzf ${localFilePath} -C $localRepoPath""".!!
+        log.info(output)
+
+        val delOut = s"""rm $localFilePath"""
+        log.info(delOut)
+      }
+
+      fileBuff += join(File.separator,
+        localRepoPath, fileName.substring(0, fileName.indexOf("\\.")))
+    }
+    fileBuff.toList
+  }
+
+  def buildCloneCommand(repoName: String, cloneUrl: String): Seq[String] = {
+    // TODO: Use case matching
+    if (cloneUrl.startsWith("https://github.com/")) {
+      bashCmdsFromDir(localRepoPath,
+        Seq(
+          s"""cd ${localRepoPath}""",
+          s"""rm -rf ${repoName}""",
+          s"""git clone ${cloneUrl}.git"""),
+        true)
+    } else {
+      bashCmdsFromDir(localRepoPath,
+        Seq(
+          s"""cd ${localRepoPath}""",
+          s"""rm -rf ${repoName}""",
+          s"""cp -r ${cloneUrl} ."""),
+        true)
+    }
+
+  }
+
+}
+
+object GithubRepoUpdateHelper {
+
+  def bashCmdsFromDir(dir: String, cmds: Seq[String],
+                      createDir: Boolean = false): Seq[String] = {
+    val base = Seq("/bin/bash", "-c")
+    val firstCmd = if (createDir) s"""mkdir -p ${dir}""" else ""
+    base :+ cmds.foldLeft(firstCmd)((a, b) => join(" && ", a, b))
+  }
+
+  def join(sep: String, elements: String*): String = {
+    val sb = new StringBuilder
+    for (e <- elements) {
+      if (sb.length > 0 && e.length > 0) {
+        sb.append(sep)
+      }
+      sb.append(e)
+    }
+    sb.toString
+  }
+}

--- a/core/src/main/scala/com/kodebeagle/model/JavaRepo.scala
+++ b/core/src/main/scala/com/kodebeagle/model/JavaRepo.scala
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kodebeagle.model
+
+import com.kodebeagle.indexer._
+import com.kodebeagle.javaparser.JavaASTParser.ParseType
+import com.kodebeagle.javaparser.{JavaASTParser, SingleClassBindingResolver}
+import com.kodebeagle.logging.Logger
+import org.eclipse.jdt.core.dom.CompilationUnit
+
+class JavaRepo(baseRepo: GithubRepo) extends Repo with Logger
+  with LazyLoadSupport {
+
+  // TODO: This constants needs to go somewhere else
+  private val JAVA_LANGUAGE = "java"
+
+  override def files: List[JavaFileInfo] = {
+    if (languages.contains(JAVA_LANGUAGE)) {
+      baseRepo.files
+        .filter(_.fileName.endsWith(".java"))
+        .map(f => new JavaFileInfo(f))
+    } else {
+      Nil
+    }
+  }
+
+  override def statistics: JavaRepoStatistics = new JavaRepoStatistics(baseRepo.statistics)
+
+  override def languages: Set[String] = baseRepo.languages
+}
+
+class JavaFileInfo(baseFile: FileInfo) extends FileInfo with LazyLoadSupport {
+
+  assert(baseFile.fileName.endsWith(".java"),
+    s"A java file is expected. Actual file: ${baseFile.fileName}")
+
+  private var _searchableRefs: Option[Set[ExternalTypeReference]] = None
+
+  private var _fileMetaData: Option[FileMetaData] = None
+
+  private var _imports: Option[Set[String]] = None
+
+  def searchableRefs: Set[ExternalTypeReference] = {
+    getOrCompute(_searchableRefs, () => {
+      parse()
+      _searchableRefs.get
+    })
+  }
+
+  def fileMetaData: FileMetaData = {
+    getOrCompute(_fileMetaData, () => {
+      parse()
+      _fileMetaData.get
+    })
+  }
+
+  def imports: Set[String] = {
+    getOrCompute(_imports, () => {
+      parse()
+      _imports.get
+    })
+  }
+
+  override def fileName: String = baseFile.fileName
+
+  override def sloc: Int = baseFile.sloc
+
+  override def fileContent: String = baseFile.fileContent
+
+  override def language: String = baseFile.language
+
+  override def repoId: Int = baseFile.repoId
+
+  override def repoFileLocation: String = baseFile.repoFileLocation
+
+  def isTestFile(): Boolean = imports.exists(_.contains("org.junit"))
+
+  /**
+    * This method parses the java file and updates all that needs to be exposed by this class.
+    *
+    * The method is called lazily on when the data depending on parse is first requested, and
+    * then all such data is computed and stored in the fields of the class.
+    *
+    * @return
+    */
+  private def parse() = {
+    import scala.collection.JavaConversions._
+
+    val parser: JavaASTParser = new JavaASTParser(true)
+    val cu: CompilationUnit = parser.getAST(fileContent, ParseType.COMPILATION_UNIT).asInstanceOf
+    val scbr: SingleClassBindingResolver = new SingleClassBindingResolver(cu)
+    scbr.resolve()
+
+    val nodeVsType = scbr.getTypesAtPosition
+    // TODO: Get this properly
+    val score = 0
+    val externalTypeRefs = extractExtTypeRefs(scbr, cu, score)
+    val fileMetaData = FileMetaDataIndexer.generateMetaData(scbr, cu, repoId, fileName)
+
+    _imports = Option(scbr.getImports.toSet)
+    _searchableRefs = Option(externalTypeRefs)
+    _fileMetaData = Option(fileMetaData)
+  }
+
+  private def extractExtTypeRefs(scbr: SingleClassBindingResolver,
+                                 cu: CompilationUnit, score: Int): Set[ExternalTypeReference] = {
+    import scala.collection.JavaConversions._
+    val externalTypeRefs = scbr.getMethodInvoks.values()
+      // for every method in the class
+      .map(invokList => {
+      // group the method call by the type of object
+      invokList.groupBy(_.getTargetType)
+        // then map the grp to:
+        .map { case (typ, grp) =>
+        // 1. get list of locations where this type was invoked
+        val lineList = grp.map(t => {
+          val line = cu.getLineNumber(t.getLocation)
+          val col = cu.getColumnNumber(t.getLocation)
+          new ExternalLine(line, col, col + t.getLength)
+        }).toList
+
+        // 2. method names invoked of this type along with a list of their respective locations
+        val propSet = grp.groupBy(_.getMethodName).map { case (prop, pgrp) =>
+          new Property(prop, pgrp.map(t => {
+            val line = cu.getLineNumber(t.getLocation)
+            val col = cu.getColumnNumber(t.getLocation)
+            // TODO: This seems redundant (??)
+            new ExternalLine(line, col, col + t.getLength)
+          }).toList)
+        }.toSet
+
+        new ExternalType(typ, lineList, propSet)
+
+      }
+    }.toSet)
+      // Convert it back to a set of top level ExternalTypeReference object
+      .map(extSet => new ExternalTypeReference(repoId, fileName, extSet, score))
+      .toSet
+    externalTypeRefs
+  }
+
+}
+
+class JavaRepoStatistics(repoStatistics: RepoStatistics) extends RepoStatistics {
+
+  override def sloc: Int = repoStatistics.sloc
+
+  override def fileCount: Int = repoStatistics.fileCount
+
+  override def size: Long = repoStatistics.size
+}

--- a/core/src/main/scala/com/kodebeagle/model/Repo.scala
+++ b/core/src/main/scala/com/kodebeagle/model/Repo.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kodebeagle.model
+
+trait Repo extends Serializable {
+
+  def files: List[FileInfo]
+
+  def statistics: RepoStatistics
+
+  def languages: Set[String]
+}
+
+trait FileInfo extends Serializable {
+
+  /**
+    * A name for this file in repository that uniquely identifies it.
+    *
+    * e.g. the path of file in the repository hierarchy.
+    *
+    * repoFileLocation is complete Repository URL of particular file
+    *
+    * @return
+    */
+  def fileName: String
+
+  def language: String
+
+  def fileContent: String
+
+  def sloc: Int
+
+  def repoId: Int
+
+  def repoFileLocation: String
+}
+
+trait RepoStatistics {
+
+  def sloc: Int
+
+  def fileCount: Int
+
+  def size: Long
+}
+
+trait LazyLoadSupport {
+
+  def getOrCompute[T](maybeVal: Option[T], compute: () => T): T = {
+    maybeVal match {
+      case Some(value) => value
+      case None => compute()
+    }
+  }
+}

--- a/core/src/main/scala/com/kodebeagle/spark/job/RepoAnalyzerJob.scala
+++ b/core/src/main/scala/com/kodebeagle/spark/job/RepoAnalyzerJob.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.kodebeagle.spark.job
+
+import com.kodebeagle.configuration.KodeBeagleConfig
+import com.kodebeagle.model.GithubRepo
+import com.kodebeagle.spark.producer.{ScalaIndexProducer, JavaIndexProducer}
+import com.kodebeagle.spark.util.SparkIndexJobHelper._
+import org.apache.spark.{SerializableWritable, SparkConf}
+
+
+/**
+  * Created by sachint on 5/7/16.
+  */
+object RepoAnalyzerJob {
+
+  def main(args: Array[String]): Unit = {
+    val conf = new SparkConf()
+      .setMaster(KodeBeagleConfig.sparkMaster)
+      .setAppName("RepoAnalyzerJob")
+    val sc = createSparkContext(conf)
+    val rdd = sc.parallelize(Array("niesteszeck/idDHT11", "mrjoes/flask-babel","rmcastil/dotfiles"))
+
+    // TODO: SerializableWritable is marked as developer API. (But then we are also developers ;) )
+    val confBroadcast = sc.broadcast(new SerializableWritable(sc.hadoopConfiguration))
+    val count = rdd.map(f => new GithubRepo(confBroadcast.value.value, f)).count()
+    print("Count is >>>>>\n\n" + count + "\n\n")
+  }
+}


### PR DESCRIPTION
This commit does the following --
1. Creates Repo/File model class heirarchy to represent a repo and file.
2. Implements the new parsing logic to use a single parse for both ref indexes as well as metadata indexes.
3. More logical packaging of model and index intities files.

fixes #522
fixes #521 (Refactor code to use the same java parser througout.)