### PR TITLE
[core] #585 Added spark specific logging.

### DIFF
--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -29,7 +29,9 @@ kodebeagle.indexing.linesOfContext=20
 kodebeagle.spark.master=spark://192.168.2.145:7077
 #kodebeagle.spark.master=local[4]
 kodebeagle.metadata.range=<start-end>
-kodebeagle.metadata.chunk-size=<chunk-size>
+kodebeagle.metadata.chunk-size=1000
+// In MB's
+kodebeagle.github.repo.max.size=800
 kodebeagle.httpClient.max-retries=5
 kodebeagle.spark.index.outputDir=tokens
 kodebeagle.spark.repo.outputDir=repo
@@ -39,6 +41,7 @@ kodebeagle.spark.method.outputDir=method
 kodebeagle.repo.cloneDir=/tmp/kodebeagle
 kodebeagle.repo.storeDir=/kodebeagle/repos/
 kodebeagle.repo.update.days=50
+kodebeagle.repo.min.stars=25
 
 # Or local path /repos/ etc
 kodebeagle.repo.remoteUrlPrefix=https://github.com/

--- a/core/src/main/scala/com/kodebeagle/configuration/KodeBeagleConfig.scala
+++ b/core/src/main/scala/com/kodebeagle/configuration/KodeBeagleConfig.scala
@@ -54,6 +54,8 @@ object KodeBeagleConfig extends ConfigReader {
   private[kodebeagle] val esourceFileIndex: String = get("kodebeagle.es.sourceFileIndex").get
   private[kodebeagle] val metadataRange: String = get("kodebeagle.metadata.range").get
   private[kodebeagle] val chunkSize: String = get("kodebeagle.metadata.chunk-size").get
+  private[kodebeagle] val maxGitFileSize = get("kodebeagle.github.repo.max.size").get.toInt
+  private[kodebeagle] val minStars = get("kodebeagle.repo.min.stars").get.toInt
   private[kodebeagle] val httpClientMaxRetries: Int =
     get("kodebeagle.httpClient.max-retries").get.toInt
 

--- a/core/src/main/scala/com/kodebeagle/logging/Logger.scala
+++ b/core/src/main/scala/com/kodebeagle/logging/Logger.scala
@@ -17,8 +17,25 @@
 
 package com.kodebeagle.logging
 
+import org.apache.spark.TaskContext
 import org.slf4j.LoggerFactory
+
 
 trait Logger {
   val log = LoggerFactory.getLogger(this.getClass.getName)
+}
+
+object LoggerUtils {
+  implicit  class SparkLogger(log: org.slf4j.Logger) extends {
+
+    private def appendContextInfo(msg: String) = {
+      val maybeContext = Option(TaskContext.get())
+      maybeContext match {
+        case Some(c) => s"Task[${c.taskAttemptId()}.${c.attemptNumber()}] ${msg}"
+        case None => msg
+      }
+    }
+
+    def sparkInfo(msg: String): Unit = log.info(appendContextInfo(msg))
+  }
 }

--- a/core/src/main/scala/com/kodebeagle/model/GithubRepo.scala
+++ b/core/src/main/scala/com/kodebeagle/model/GithubRepo.scala
@@ -49,7 +49,7 @@ class GithubRepo protected()
   private var _files: Option[List[GithubFileInfo]] = None
   private var _stats: Option[RepoStatistics] = None
   private var _languages: Option[Set[String]] = None
-  protected var _repoGitFiles: Option[List[String]] = None
+  protected var _repoGitFile: Option[String] = None
   var repoInfo: Option[GithubRepoInfo] = None
 
 
@@ -60,9 +60,12 @@ class GithubRepo protected()
     if (repoUpdateHelper.shouldUpdate()) {
       repoUpdateHelper.update()
     }
-    _repoGitFiles = Option(repoUpdateHelper.downloadLocalFromDfs())
     repoInfo = Option(githubRepoInfo)
-    this
+    _repoGitFile = repoUpdateHelper.downloadLocalFromDfs()
+    _repoGitFile match {
+      case Some(git) => this
+      case None => throw new IllegalStateException("Repo could not be downloaded.")
+    }
   }
 
   override def files: List[GithubFileInfo] = {
@@ -87,7 +90,7 @@ class GithubRepo protected()
   }
 
   def repository: Repository = {
-    val repoPath: String = _repoGitFiles.get(0)
+    val repoPath: String = _repoGitFile.get
     val builder: FileRepositoryBuilder = new FileRepositoryBuilder
     builder.setGitDir(new File(s"$repoPath/.git")).readEnvironment.findGitDir.build
   }

--- a/core/src/main/scala/com/kodebeagle/model/JavaRepo.scala
+++ b/core/src/main/scala/com/kodebeagle/model/JavaRepo.scala
@@ -119,6 +119,16 @@ class JavaFileInfo(baseFile: GithubFileInfo) extends FileInfo with LazyLoadSuppo
 
   def isTestFile(): Boolean = imports.exists(_.contains("org.junit"))
 
+  // Reset the generated indices to None so that the older strings can be GCed
+  def free(): Unit = {
+    _repoPath = None
+    _searchableRefs = None
+    _fileMetaData = None
+    _imports = None
+    _javaDoc = None
+    _typesInFile = None
+  }
+
   /**
     * This method parses the java file and updates all that needs to be exposed by this class.
     *

--- a/core/src/test/scala/com/kodebeagle/model/Mocks.scala
+++ b/core/src/test/scala/com/kodebeagle/model/Mocks.scala
@@ -25,8 +25,7 @@ class MockedGithubRepo() extends GithubRepo() {
   val mockGithubRepoInfo = new GithubRepoInfo(1, "himukr", "google-grp-scraper",
     "himukr/google-grp-scraper", false, false, 100, 5, "", 1, 5,"master", 5)
   def init(configurationTest: Configuration, repoPathTest: String): MockedGithubRepo = {
-    _repoGitFiles = Option(
-      List(s"${KodeBeagleConfig.repoCloneDir}/himukr/google-grp-scraper"))
+    _repoGitFile = Option(s"${KodeBeagleConfig.repoCloneDir}/himukr/google-grp-scraper")
     repoInfo = Option(mockGithubRepoInfo)
     this
   }


### PR DESCRIPTION
1. Fixed file close
2. Resetting the strings inside a fileinfo to None so as to make them available for GC once a single file is processed
3. Added the files size check for files from hdfs.
4. Added min stars as external property in config.
5. Making sure that executor size remains within limit.

fixes #585
closes #586