### PR TITLE
[core] #588 Made the returnType of a declared method to be fullyQualified name

### DIFF
--- a/core/src/main/java/com/kodebeagle/javaparser/MethodInvocationResolver.java
+++ b/core/src/main/java/com/kodebeagle/javaparser/MethodInvocationResolver.java
@@ -286,7 +286,7 @@ public class MethodInvocationResolver extends TypeResolver {
         String methodName = nameNode.toString();
         String returnType = "";
         if (node.getReturnType2() != null) {
-            returnType = node.getReturnType2().toString();
+            returnType = getNameOfType(node.getReturnType2());
         }
 
         Map<String, String> params = new HashMap<>();

--- a/core/src/test/scala/com/kodebeagle/parser/JavaParserSuite.scala
+++ b/core/src/test/scala/com/kodebeagle/parser/JavaParserSuite.scala
@@ -83,6 +83,15 @@ class MethodInvocationResolverSuite extends FunSuite with BeforeAndAfterAll
     }
   }
 
+  test("return type test") {
+    import scala.collection.JavaConversions._
+    val methodDeclarations = enumTestFileResolver.get.getDeclaredMethods
+    if(methodDeclarations.size() > 0) {
+      val methodDecl = methodDeclarations.find(_.getMethodName == "handleResponse").get
+      assert("org.apache.http.impl.client.RoutedRequest".equals(methodDecl.getReturnType))
+    }
+  }
+
   test("imports test") {
     val imports = enumTestFileResolver.get.getImports
     assert(imports.size() == 65)


### PR DESCRIPTION
Made the returnType of a declared method to be fullyQualified name instead of class name
fixes #588 
closes #589 