### PR TITLE
[core] #627 Field length norm disabled for typereference contexts

### DIFF
--- a/bin/upload_to_es.sh
+++ b/bin/upload_to_es.sh
@@ -115,16 +115,19 @@ curl -X PUT localhost:9200/java/typereference/_mapping -d '{
 						"properties": {
 							"name": {
 								"type": "string",
+								"norms": { "enabled": false },
 								"analyzer": "keyword_analyzer"
 							},
 							"props": {
 								"type": "string",
+								"norms": { "enabled": false },
 								"analyzer": "keyword_analyzer"
 							}
 						}
 					},
 					"text": {
 						"type": "string",
+						"norms": { "enabled": false },
 						"analyzer": "simple"
 					}
 				}


### PR DESCRIPTION
    fixes #627
    closes #628